### PR TITLE
use from_{ref,mut} to eliminate casts to pointers

### DIFF
--- a/src/arch/aarch64/mod.rs
+++ b/src/arch/aarch64/mod.rs
@@ -81,7 +81,7 @@ pub fn output_message_byte(byte: u8) {
 }
 
 pub unsafe fn get_memory(_memory_size: u64) -> u64 {
-	(ptr::from_ref(unsafe { &kernel_end }).addr() as u64).align_up(LargePageSize::SIZE as u64)
+	(ptr::addr_of!(kernel_end).addr() as u64).align_up(LargePageSize::SIZE as u64)
 }
 
 pub fn find_kernel() -> &'static [u8] {
@@ -155,46 +155,44 @@ pub unsafe fn boot_kernel(kernel_info: LoadedKernel) -> ! {
 	let uart_address: u32 = unsafe { COM1.get_port() };
 	info!("Detect UART at {:#x}", uart_address);
 
-	let pgt_slice = unsafe { core::slice::from_raw_parts_mut(ptr::from_mut(&mut l0_pgtable), 512) };
+	let pgt_slice = unsafe { core::slice::from_raw_parts_mut(ptr::addr_of_mut!(l0_pgtable), 512) };
 	for i in pgt_slice.iter_mut() {
 		*i = 0;
 	}
-	pgt_slice[0] = ptr::from_ref(unsafe { &l1_pgtable }).addr() as u64 + PT_PT;
-	pgt_slice[511] = ptr::from_ref(unsafe { &l0_pgtable }).addr() as u64 + PT_PT + PT_SELF;
+	pgt_slice[0] = ptr::addr_of!(l1_pgtable).addr() as u64 + PT_PT;
+	pgt_slice[511] = ptr::addr_of!(l0_pgtable).addr() as u64 + PT_PT + PT_SELF;
 
-	let pgt_slice = unsafe { core::slice::from_raw_parts_mut(ptr::from_mut(&mut l1_pgtable), 512) };
+	let pgt_slice = unsafe { core::slice::from_raw_parts_mut(ptr::addr_of_mut!(l1_pgtable), 512) };
 	for i in pgt_slice.iter_mut() {
 		*i = 0;
 	}
-	pgt_slice[0] = ptr::from_ref(unsafe { &l2_pgtable }).addr() as u64 + PT_PT;
-	pgt_slice[1] = ptr::from_ref(unsafe { &l2k_pgtable }).addr() as u64 + PT_PT;
+	pgt_slice[0] = ptr::addr_of!(l2_pgtable).addr() as u64 + PT_PT;
+	pgt_slice[1] = ptr::addr_of!(l2k_pgtable).addr() as u64 + PT_PT;
 
-	let pgt_slice = unsafe { core::slice::from_raw_parts_mut(ptr::from_mut(&mut l2_pgtable), 512) };
+	let pgt_slice = unsafe { core::slice::from_raw_parts_mut(ptr::addr_of_mut!(l2_pgtable), 512) };
 	for i in pgt_slice.iter_mut() {
 		*i = 0;
 	}
-	pgt_slice[0] = ptr::from_ref(unsafe { &l3_pgtable }).addr() as u64 + PT_PT;
+	pgt_slice[0] = ptr::addr_of!(l3_pgtable).addr() as u64 + PT_PT;
 
-	let pgt_slice = unsafe { core::slice::from_raw_parts_mut(ptr::from_mut(&mut l3_pgtable), 512) };
+	let pgt_slice = unsafe { core::slice::from_raw_parts_mut(ptr::addr_of_mut!(l3_pgtable), 512) };
 	for i in pgt_slice.iter_mut() {
 		*i = 0;
 	}
 	pgt_slice[1] = uart_address as u64 + PT_MEM_CD;
 
 	// map kernel to KERNEL_START and stack below the kernel
-	let pgt_slice =
-		unsafe { core::slice::from_raw_parts_mut(ptr::from_mut(&mut l2k_pgtable), 512) };
+	let pgt_slice = unsafe { core::slice::from_raw_parts_mut(ptr::addr_of_mut!(l2k_pgtable), 512) };
 	for i in pgt_slice.iter_mut() {
 		*i = 0;
 	}
 	for (i, pgt_slice) in pgt_slice.iter_mut().enumerate().take(10) {
-		*pgt_slice = ptr::from_mut(unsafe { &mut L0mib_pgtable }).addr() as u64
-			+ (i * BasePageSize::SIZE) as u64
-			+ PT_PT;
+		*pgt_slice =
+			ptr::addr_of!(L0mib_pgtable).addr() as u64 + (i * BasePageSize::SIZE) as u64 + PT_PT;
 	}
 
 	let pgt_slice =
-		unsafe { core::slice::from_raw_parts_mut(ptr::from_mut(&mut L0mib_pgtable), 10 * 512) };
+		unsafe { core::slice::from_raw_parts_mut(ptr::addr_of_mut!(L0mib_pgtable), 10 * 512) };
 	for (i, entry) in pgt_slice.iter_mut().enumerate() {
 		*entry = RAM_START + (i * BasePageSize::SIZE) as u64 + PT_MEM;
 	}
@@ -210,7 +208,7 @@ pub unsafe fn boot_kernel(kernel_info: LoadedKernel) -> ! {
 				"msr ttbr0_el1, {}",
 				"dsb sy",
 				"isb",
-				in(reg) ptr::from_ref(&l0_pgtable).addr() as u64,
+				in(reg) ptr::addr_of!(l0_pgtable).addr() as u64,
 				options(nostack),
 		)
 	};

--- a/src/arch/x86_64/mod.rs
+++ b/src/arch/x86_64/mod.rs
@@ -173,7 +173,7 @@ pub fn find_kernel() -> &'static [u8] {
 	let elf_start = ramdisk_address as usize;
 	let elf_len = ramdisk_size as usize;
 
-	let free_memory_address = ptr::from_ref(unsafe { &kernel_end })
+	let free_memory_address = unsafe { ptr::addr_of!(kernel_end) }
 		.addr()
 		.align_up(Size2MiB::SIZE as usize);
 	// TODO: Workaround for https://github.com/hermitcore/loader/issues/96
@@ -285,8 +285,7 @@ pub unsafe fn boot_kernel(kernel_info: LoadedKernel) -> ! {
 	} = kernel_info;
 
 	// determine boot stack address
-	let new_stack =
-		(ptr::from_ref(unsafe { &kernel_end }).addr() + 0x1000).align_up(Size4KiB::SIZE as usize);
+	let new_stack = (ptr::addr_of!(kernel_end).addr() + 0x1000).align_up(Size4KiB::SIZE as usize);
 
 	let cmdline_ptr = unsafe {
 		*(sptr::from_exposed_addr(boot_params + LINUX_SETUP_HEADER_OFFSET + CMD_LINE_PTR_OFFSET))
@@ -444,7 +443,7 @@ pub unsafe fn boot_kernel(kernel_info: LoadedKernel) -> ! {
 	let multiboot = unsafe { Multiboot::from_ptr(mb_info as u64, &mut MEM).unwrap() };
 
 	// determine boot stack address
-	let mut new_stack = ptr::from_ref(unsafe { &kernel_end })
+	let mut new_stack = ptr::addr_of!(kernel_end)
 		.addr()
 		.align_up(Size4KiB::SIZE as usize);
 

--- a/src/arch/x86_64/mod.rs
+++ b/src/arch/x86_64/mod.rs
@@ -6,6 +6,7 @@ mod physicalmem;
 use core::arch::asm;
 #[cfg(all(target_os = "none", not(feature = "fc")))]
 use core::mem;
+use core::ptr;
 #[cfg(target_os = "none")]
 use core::ptr::write_bytes;
 #[cfg(target_os = "none")]
@@ -28,6 +29,7 @@ use log::info;
 use multiboot::information::MemoryManagement;
 #[cfg(all(target_os = "none", not(feature = "fc")))]
 use multiboot::information::{Multiboot, PAddr};
+use sptr::Strict;
 use uart_16550::SerialPort;
 use x86_64::structures::paging::{PageSize, PageTableFlags, Size2MiB, Size4KiB};
 
@@ -171,8 +173,9 @@ pub fn find_kernel() -> &'static [u8] {
 	let elf_start = ramdisk_address as usize;
 	let elf_len = ramdisk_size as usize;
 
-	let free_memory_address =
-		(unsafe { &kernel_end } as *const u8 as usize).align_up(Size2MiB::SIZE as usize);
+	let free_memory_address = ptr::from_ref(unsafe { &kernel_end })
+		.addr()
+		.align_up(Size2MiB::SIZE as usize);
 	// TODO: Workaround for https://github.com/hermitcore/loader/issues/96
 	let free_memory_address = cmp::max(free_memory_address, 0x800000);
 	info!("Intialize PhysAlloc with {:#x}", free_memory_address);
@@ -283,7 +286,7 @@ pub unsafe fn boot_kernel(kernel_info: LoadedKernel) -> ! {
 
 	// determine boot stack address
 	let new_stack =
-		(unsafe { &kernel_end } as *const u8 as usize + 0x1000).align_up(Size4KiB::SIZE as usize);
+		(ptr::from_ref(unsafe { &kernel_end }).addr() + 0x1000).align_up(Size4KiB::SIZE as usize);
 
 	let cmdline_ptr = unsafe {
 		*(sptr::from_exposed_addr(boot_params + LINUX_SETUP_HEADER_OFFSET + CMD_LINE_PTR_OFFSET))
@@ -441,8 +444,9 @@ pub unsafe fn boot_kernel(kernel_info: LoadedKernel) -> ! {
 	let multiboot = unsafe { Multiboot::from_ptr(mb_info as u64, &mut MEM).unwrap() };
 
 	// determine boot stack address
-	let mut new_stack =
-		(unsafe { &kernel_end } as *const u8 as usize).align_up(Size4KiB::SIZE as usize);
+	let mut new_stack = ptr::from_ref(unsafe { &kernel_end })
+		.addr()
+		.align_up(Size4KiB::SIZE as usize);
 
 	if new_stack + KERNEL_STACK_SIZE as usize > unsafe { mb_info } {
 		new_stack = (unsafe { mb_info } + mem::size_of::<Multiboot<'_, '_>>())


### PR DESCRIPTION
As it stands, the PR requires `ptr_from_ref` and `strict_provenance` to land in stable. If the `ptr_from_ref` lands first, the branch can be updated to make use of the polyfill for the `pointer::addr` method in the sptr crate, as instructed in [its documentation](https://docs.rs/sptr/latest/sptr/#applying-the-overlay).