### PR TITLE
fix(xtask): enable clippy for x86_64-uefi

### DIFF
--- a/src/arch/mod.rs
+++ b/src/arch/mod.rs
@@ -2,7 +2,7 @@
 pub use crate::arch::aarch64::*;
 #[cfg(target_arch = "riscv64")]
 pub use crate::arch::riscv64::*;
-#[cfg(target_arch = "x86_64")]
+#[cfg(all(target_arch = "x86_64", target_os = "none"))]
 pub use crate::arch::x86_64::*;
 
 #[cfg(target_arch = "aarch64")]
@@ -11,5 +11,5 @@ pub mod aarch64;
 #[cfg(target_arch = "riscv64")]
 pub mod riscv64;
 
-#[cfg(target_arch = "x86_64")]
+#[cfg(all(target_arch = "x86_64", target_os = "none"))]
 pub mod x86_64;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -3,6 +3,7 @@
 /// Adapted from [`std::print`].
 ///
 /// [`std::print`]: https://doc.rust-lang.org/stable/std/macro.print.html
+#[cfg(target_os = "none")]
 #[macro_export]
 macro_rules! print {
     ($($arg:tt)*) => {{
@@ -15,6 +16,7 @@ macro_rules! print {
 /// Adapted from [`std::println`].
 ///
 /// [`std::println`]: https://doc.rust-lang.org/stable/std/macro.println.html
+#[cfg(target_os = "none")]
 #[macro_export]
 macro_rules! println {
     () => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,10 +18,10 @@ mod none;
 #[cfg(target_os = "uefi")]
 mod uefi;
 
-use core::fmt::{self, Write};
-
 #[doc(hidden)]
-fn _print(args: fmt::Arguments<'_>) {
+fn _print(args: core::fmt::Arguments<'_>) {
+	use core::fmt::Write;
+
 	unsafe {
 		console::CONSOLE.write_fmt(args).unwrap();
 	}

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,13 +11,16 @@ mod macros;
 #[cfg(target_os = "none")]
 mod allocator;
 mod arch;
+#[cfg(target_os = "none")]
 mod console;
+#[cfg(target_os = "none")]
 mod log;
 #[cfg(target_os = "none")]
 mod none;
 #[cfg(target_os = "uefi")]
 mod uefi;
 
+#[cfg(target_os = "none")]
 #[doc(hidden)]
 fn _print(args: core::fmt::Arguments<'_>) {
 	use core::fmt::Write;

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -142,11 +142,10 @@ impl flags::Clippy {
 	fn run(self) -> Result<()> {
 		let sh = Shell::new()?;
 
-		// TODO: Enable clippy for x86_64-uefi
-		// https://github.com/hermitcore/loader/issues/122
 		for target in [
 			Target::X86_64,
 			Target::X86_64Fc,
+			Target::X86_64Uefi,
 			Target::AArch64,
 			Target::Riscv64,
 		] {


### PR DESCRIPTION
Closes https://github.com/hermit-os/loader/issues/122.