### PR TITLE
lib: riscv64: use RISC-V SBI 2.0 ratified DBCN write instead of deprecated legacy console write

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -297,7 +297,7 @@ dependencies = [
  "naked-function",
  "qemu-exit",
  "riscv",
- "sbi",
+ "sbi-rt",
  "spinning_top",
  "sptr",
  "uart_16550",
@@ -494,10 +494,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 
 [[package]]
-name = "sbi"
-version = "0.2.0"
+name = "sbi-rt"
+version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29cb0870400aca7e4487e8ec1e93f9d4288da763cb1da2cedc5102e62b6522ad"
+checksum = "7fbaa69be1eedc61c426e6d489b2260482e928b465360576900d52d496a58bd0"
+dependencies = [
+ "sbi-spec",
+]
+
+[[package]]
+name = "sbi-spec"
+version = "0.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e36312fb5ddc10d08ecdc65187402baba4ac34585cb9d1b78522ae2358d890"
 
 [[package]]
 name = "scopeguard"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ qemu-exit = "3"
 fdt = "0.1"
 naked-function = "0.1"
 riscv = "0.11"
-sbi = "0.2"
+sbi-rt = "0.0.3"
 sptr = "0.3"
 
 [profile.release]

--- a/src/arch/riscv64/mod.rs
+++ b/src/arch/riscv64/mod.rs
@@ -16,7 +16,7 @@ use sptr::Strict;
 
 pub fn message_output_init() {}
 
-pub use sbi::legacy::console_putchar as output_message_byte;
+pub use sbi_rt::console_write_byte as output_message_byte;
 
 fn find_kernel_linux(chosen: &FdtNode<'_, '_>) -> Option<&'static [u8]> {
 	let initrd_start = chosen.property("linux,initrd-start")?.as_usize()?;


### PR DESCRIPTION
Legacy extensions are deprecated in SBI 0.2 dated back to 2021; some of the SBI implementations have already dropped support for legacy console, resulting in no console output for hermit OS loader.

To solve this problem, we use its replacement in the SBI 2.0 DBCN extension, which is supported by modern SBI firmwares. We do this by modify our code to use the `console_write_byte` function from `sbi-rt`.

r? @mkroening 