### PR TITLE
ci: upgrade OpenSBI to version 1.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
   merge_group:
 
 env:
+  GH_TOKEN: ${{ github.token }}
   RUSTFLAGS: -Dwarnings
   RUSTDOCFLAGS: -Dwarnings
 
@@ -70,6 +71,11 @@ jobs:
             lfs: true
       - name: Install stable Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+      - name: Dowload OpenSBI
+        if: matrix.target == 'riscv64'
+        run: |
+          gh release download v1.4 --repo riscv-software-src/opensbi --pattern 'opensbi-*-rv-bin.tar.xz'
+          tar -xvf opensbi-*-rv-bin.tar.xz opensbi-1.4-rv-bin/share/opensbi/lp64/generic/firmware/fw_jump.bin
       - name: Run VM (hello_world, dev)
         run: cargo xtask ci qemu --target ${{ matrix.target }}
       - name: Run VM (hello_world, release)

--- a/xtask/src/ci/qemu.rs
+++ b/xtask/src/ci/qemu.rs
@@ -86,7 +86,12 @@ impl Qemu {
 		} else if self.build.target() == Target::Aarch64 {
 			vec!["-machine".to_string(), "virt,gic-version=3".to_string()]
 		} else if self.build.target() == Target::Riscv64 {
-			vec!["-machine".to_string(), "virt".to_string()]
+			vec![
+				"-machine".to_string(),
+				"virt".to_string(),
+				"-bios".to_string(),
+				"opensbi-1.4-rv-bin/share/opensbi/lp64/generic/firmware/fw_jump.bin".to_string(),
+			]
 		} else {
 			vec![]
 		}
@@ -207,6 +212,9 @@ impl Qemu {
 			}
 			Target::Aarch64 => {
 				memory = memory.max(256);
+			}
+			Target::Riscv64 => {
+				memory = memory.max(128);
 			}
 			_ => {}
 		}


### PR DESCRIPTION
OpenSBI added experimental support for the SBI debug console extension in [`v1.3`](https://github.com/riscv-software-src/opensbi/releases/tag/v1.3).

For now, we'd like to stick to the reference implementation of SBI for now.

See https://github.com/hermit-os/loader/pull/306.