### PR TITLE
feat: baremetalsupport aarch64

### DIFF
--- a/.buildconfig
+++ b/.buildconfig
@@ -1,0 +1,11 @@
+[default]
+name=Default
+runtime=host
+toolchain=default
+config-opts=
+run-opts=
+prefix=/home/fridericus/.var/app/org.gnome.Builder/cache/gnome-builder/install/loader/host
+app-id=
+postbuild=
+prebuild=
+run-command=

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
-    // "rust-analyzer.cargo.target": "aarch64-unknown-none-softfloat",
+    "rust-analyzer.cargo.target": "aarch64-unknown-none-softfloat",
     // "rust-analyzer.cargo.target": "riscv64imac-unknown-none-elf",
-    "rust-analyzer.cargo.target": "x86_64-unknown-none",
+    // "rust-analyzer.cargo.target": "x86_64-unknown-none",
     // "rust-analyzer.cargo.target": "x86_64-unknown-uefi",
     "rust-analyzer.check.overrideCommand": [
         "cargo",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -318,7 +318,7 @@ dependencies = [
  "uart_16550",
  "uefi",
  "vm-fdt",
- "volatile-register",
+ "volatile 0.6.1",
  "x86_64",
 ]
 
@@ -713,12 +713,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
-name = "vcell"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77439c1b53d2303b20d9459b1ade71a83c716e3f9c34f3228c00e6f185d6c002"
-
-[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -740,12 +734,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "442887c63f2c839b346c192d047a7c87e73d0689c9157b00b53dcc27dd5ea793"
 
 [[package]]
-name = "volatile-register"
-version = "0.2.2"
+name = "volatile"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de437e2a6208b014ab52972a27e59b33fa2920d3e00fe05026167a1c509d19cc"
+checksum = "af8ca9a5d4debca0633e697c88269395493cebf2e10db21ca2dbde37c1356452"
 dependencies = [
- "vcell",
+ "volatile-macro",
+]
+
+[[package]]
+name = "volatile-macro"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65c67ce935f3b4329e473ecaff7bab444fcdc3d1d19f8bae61fabfa90b84f93e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -875,7 +880,7 @@ dependencies = [
  "bit_field",
  "bitflags 2.5.0",
  "rustversion",
- "volatile",
+ "volatile 0.4.6",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -318,6 +318,7 @@ dependencies = [
  "uart_16550",
  "uefi",
  "vm-fdt",
+ "volatile-register",
  "x86_64",
 ]
 
@@ -712,6 +713,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
+name = "vcell"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77439c1b53d2303b20d9459b1ade71a83c716e3f9c34f3228c00e6f185d6c002"
+
+[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -731,6 +738,15 @@ name = "volatile"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "442887c63f2c839b346c192d047a7c87e73d0689c9157b00b53dcc27dd5ea793"
+
+[[package]]
+name = "volatile-register"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de437e2a6208b014ab52972a27e59b33fa2920d3e00fe05026167a1c509d19cc"
+dependencies = [
+ "vcell",
+]
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ x86_64 = { version = "0.15", default-features = false, features = ["instructions
 aarch64-cpu = "9"
 hermit-dtb = { version = "0.1" }
 goblin = { version = "0.8", default-features = false, features = ["elf64"] }
-volatile-register = "0.2.2"
+volatile =  { version = "0.6.1", features = ["derive"] }
 
 [target.'cfg(target_os = "none")'.dependencies]
 allocator-api2 = { version = "0.2", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ x86_64 = { version = "0.15", default-features = false, features = ["instructions
 aarch64-cpu = "9"
 hermit-dtb = { version = "0.1" }
 goblin = { version = "0.8", default-features = false, features = ["elf64"] }
+volatile-register = "0.2.2"
 
 [target.'cfg(target_os = "none")'.dependencies]
 allocator-api2 = { version = "0.2", default-features = false }

--- a/src/arch/aarch64/console.rs
+++ b/src/arch/aarch64/console.rs
@@ -1,21 +1,14 @@
+use core::num::NonZeroU32;
 use hermit_dtb::Dtb;
 
-use crate::arch::drivers::qemu_serial::QemuSerial;
+use crate::arch::drivers::xlnx_serial::XlnxSerial;
+use crate::arch::drivers::SerialDriver;
 
 pub struct Console {
-	stdout: &'static mut dyn SerialDriver,
+	stdout: XlnxSerial,
 }
 
-pub trait SerialDriver {
-    fn init(&mut self);
-    fn set_baud(&self, baud_rate: u32);
-    fn putc(&mut self, c: u8);
-    fn getc(&self) -> u8;
-    //fn putstr(&self, s: &[u8])
-    fn get_addr(&self) -> u32;
-}
-
-fn stdout() -> &'static mut dyn SerialDriver {
+pub fn stdout() -> XlnxSerial {
 	/// Physical address of UART0 at Qemu's virt emulation
 	const SERIAL_PORT_ADDRESS: u32 = 0x09000000;
 
@@ -23,7 +16,7 @@ fn stdout() -> &'static mut dyn SerialDriver {
 		Dtb::from_raw(sptr::from_exposed_addr(super::DEVICE_TREE as usize))
 			.expect(".dtb file has invalid header")
 	};
-
+	
 	let property = dtb.get_property("/chosen", "stdout-path");
 	let uart_address = if let Some(stdout) = property {
 		let stdout = core::str::from_utf8(stdout)
@@ -32,30 +25,42 @@ fn stdout() -> &'static mut dyn SerialDriver {
 		if let Some(pos) = stdout.find('@') {
 			let len = stdout.len();
 			u32::from_str_radix(&stdout[pos + 1..len], 16).unwrap_or(SERIAL_PORT_ADDRESS)
+		} else if let Some(pos) = stdout.find(':') {
+			let alias = stdout.split_at(pos).0;
+			let txt = dtb.get_property("/aliases", alias);
+			if let Some(port) = txt {
+				let port = core::str::from_utf8(port).unwrap();
+				if let Some(pos) = port.find('@') {
+					let len = stdout.len();
+					u32::from_str_radix(&stdout[pos + 1..len], 16).unwrap_or(SERIAL_PORT_ADDRESS)
+				} else { 
+					SERIAL_PORT_ADDRESS
+				}
+			} else {
+				SERIAL_PORT_ADDRESS
+			}
 		} else {
 			SERIAL_PORT_ADDRESS
 		}
 	} else {
 		SERIAL_PORT_ADDRESS
 	};
-	QemuSerial::from_addr(uart_address)
+	let mut  serial = XlnxSerial::from_addr(NonZeroU32::new(0xff000000).unwrap());
+	serial.init();
+	serial
 }
 
 impl Console {
 	pub fn write_bytes(&mut self, bytes: &[u8]) {
-		for byte in bytes.iter().copied() {
-			unsafe {
-				self.stdout.putc(byte);
-			}
-		}
+		self.stdout.putstr(bytes);
 	}
 
-	pub(super) fn get_stdout(&self) -> &dyn SerialDriver {
-		self.stdout
+	pub(super) fn get_stdout(&self) -> u32 {
+		self.stdout.get_addr()
 	}
 
 	pub(super) fn set_stdout(&mut self, stdout: u32) {
-		self.stdout = QemuSerial::from_addr(stdout);
+		self.stdout = XlnxSerial::from_addr(NonZeroU32::new(stdout).unwrap());
 	}
 }
 

--- a/src/arch/aarch64/console.rs
+++ b/src/arch/aarch64/console.rs
@@ -59,8 +59,13 @@ impl Console {
 		self.stdout.get_addr()
 	}
 
-	pub(super) fn set_stdout(&mut self, stdout: u32) {
+	pub(crate) fn set_stdout(&mut self, stdout: u32) {
 		self.stdout = XlnxSerial::from_addr(NonZeroU32::new(stdout).unwrap());
+		self.stdout.init();
+	}
+	
+	pub(crate) fn wait_empty(&mut self) {
+		self.stdout.wait_empty();
 	}
 }
 

--- a/src/arch/aarch64/console.rs
+++ b/src/arch/aarch64/console.rs
@@ -1,14 +1,16 @@
 use core::num::NonZeroU32;
 use hermit_dtb::Dtb;
 
+use crate::arch::drivers::qemu_serial::QemuSerial;
 use crate::arch::drivers::xlnx_serial::XlnxSerial;
 use crate::arch::drivers::SerialDriver;
 
 pub struct Console {
-	stdout: XlnxSerial,
+	stdout: QemuSerial,
 }
 
-pub fn stdout() -> XlnxSerial {
+///TODO: Rewrite to create serial driver available on target hardware (read from dtb) 
+pub fn stdout() -> QemuSerial {
 	/// Physical address of UART0 at Qemu's virt emulation
 	const SERIAL_PORT_ADDRESS: u32 = 0x09000000;
 
@@ -45,7 +47,7 @@ pub fn stdout() -> XlnxSerial {
 	} else {
 		SERIAL_PORT_ADDRESS
 	};
-	let mut  serial = XlnxSerial::from_addr(NonZeroU32::new(0xff000000).unwrap());
+	let mut  serial = QemuSerial::from_addr(NonZeroU32::new(uart_address).unwrap());
 	serial.init();
 	serial
 }
@@ -60,7 +62,7 @@ impl Console {
 	}
 
 	pub(crate) fn set_stdout(&mut self, stdout: u32) {
-		self.stdout = XlnxSerial::from_addr(NonZeroU32::new(stdout).unwrap());
+		self.stdout = QemuSerial::from_addr(NonZeroU32::new(stdout).unwrap());
 		self.stdout.init();
 	}
 	

--- a/src/arch/aarch64/console.rs
+++ b/src/arch/aarch64/console.rs
@@ -1,22 +1,21 @@
-use core::ptr::NonNull;
-
 use hermit_dtb::Dtb;
 
 use crate::arch::drivers::qemu_serial::QemuSerial;
 
 pub struct Console {
-	stdout: &'static dyn SerialDriver,
+	stdout: &'static mut dyn SerialDriver,
 }
 
 pub trait SerialDriver {
-    fn init(&self);
+    fn init(&mut self);
     fn set_baud(&self, baud_rate: u32);
-    fn putc(&self, c: u8);
+    fn putc(&mut self, c: u8);
     fn getc(&self) -> u8;
+    //fn putstr(&self, s: &[u8])
     fn get_addr(&self) -> u32;
 }
 
-fn stdout() -> impl SerialDriver {
+fn stdout() -> &'static mut dyn SerialDriver {
 	/// Physical address of UART0 at Qemu's virt emulation
 	const SERIAL_PORT_ADDRESS: u32 = 0x09000000;
 
@@ -51,12 +50,12 @@ impl Console {
 		}
 	}
 
-	pub(super) fn get_stdout(&self) -> impl SerialDriver {
+	pub(super) fn get_stdout(&self) -> &dyn SerialDriver {
 		self.stdout
 	}
 
-	pub(super) fn set_stdout(&mut self, stdout: &'static dyn SerialDriver) {
-		self.stdout = stdout;
+	pub(super) fn set_stdout(&mut self, stdout: u32) {
+		self.stdout = QemuSerial::from_addr(stdout);
 	}
 }
 

--- a/src/arch/aarch64/drivers/mod.rs
+++ b/src/arch/aarch64/drivers/mod.rs
@@ -1,2 +1,15 @@
 pub mod qemu_serial;
 pub mod xlnx_serial;
+
+pub enum SerialSuccess<T> {
+    Success(T),
+    ERetry
+}
+pub trait SerialDriver {
+    fn init(&mut self);
+    fn set_baud(&self, baud_rate: u32);
+    fn putc(&mut self, c: u8) -> SerialSuccess<u8>;
+    fn getc(&self) -> SerialSuccess<u8>;
+    fn putstr(&mut self, s: &[u8]);
+    fn get_addr(&self) -> u32;
+}

--- a/src/arch/aarch64/drivers/mod.rs
+++ b/src/arch/aarch64/drivers/mod.rs
@@ -1,1 +1,2 @@
 pub mod qemu_serial;
+pub mod xlnx_serial;

--- a/src/arch/aarch64/drivers/mod.rs
+++ b/src/arch/aarch64/drivers/mod.rs
@@ -1,0 +1,1 @@
+pub mod qemu_serial;

--- a/src/arch/aarch64/drivers/mod.rs
+++ b/src/arch/aarch64/drivers/mod.rs
@@ -12,4 +12,5 @@ pub trait SerialDriver {
     fn getc(&self) -> SerialSuccess<u8>;
     fn putstr(&mut self, s: &[u8]);
     fn get_addr(&self) -> u32;
+    fn wait_empty(&mut self);
 }

--- a/src/arch/aarch64/drivers/qemu_serial.rs
+++ b/src/arch/aarch64/drivers/qemu_serial.rs
@@ -1,0 +1,30 @@
+use core::ptr::NonNull;
+use crate::arch::aarch64::console::SerialDriver;
+use volatile_register::{RW, RO};
+
+#[repr(C)]
+pub struct QemuSerial {
+    pub out: RW<u8>,
+}
+
+impl QemuSerial {
+    pub fn from_addr(base_addr: u32) -> &'static mut QemuSerial {
+        unsafe { &mut *(base_addr as *mut QemuSerial) }
+    }
+}
+
+impl SerialDriver for QemuSerial {
+    fn init(&self) {return;}
+    fn set_baud(&self, baud_rate: u32) {return;}
+    fn putc(&self, c: u8) {
+        unsafe {
+            self.out.write(c);
+        }
+    }
+    fn getc(&self) -> u8 {
+        'A' as u8
+    }
+    fn get_addr(&self) -> u32 {
+        unsafe { core::ptr::addr_of!(self) as u32 }
+    }
+}

--- a/src/arch/aarch64/drivers/qemu_serial.rs
+++ b/src/arch/aarch64/drivers/qemu_serial.rs
@@ -28,6 +28,7 @@ impl SerialDriver for QemuSerial {
         self.regs.as_mut_ptr().out().write(c);
         Success(c)
     }
+    ///TODO: Implement actual read functionality.
     fn getc(&self) -> SerialSuccess<u8> {
         Success('A' as u8)
     }

--- a/src/arch/aarch64/drivers/qemu_serial.rs
+++ b/src/arch/aarch64/drivers/qemu_serial.rs
@@ -1,32 +1,43 @@
-use crate::arch::aarch64::console::SerialDriver;
+use core::num::NonZeroU32;
+use core::ptr::NonNull;
+use crate::arch::drivers::{SerialDriver, SerialSuccess};
 use volatile::{VolatileFieldAccess, VolatileRef};
+use crate::arch::drivers::SerialSuccess::Success;
 
 #[repr(C)]
 #[derive(VolatileFieldAccess)]
-pub struct QemuSerial {
-    pub out: u8,
+struct QemuPort {
+    out: u8,
 }
 
+pub struct QemuSerial {
+    regs: VolatileRef<'static, QemuPort>
+}
+
+
 impl QemuSerial {
-    pub fn from_addr(base_addr: u32) -> &'static mut QemuSerial {
-        unsafe { &mut *(base_addr as *mut QemuSerial) }
+    pub fn from_addr(base_addr: NonZeroU32) -> QemuSerial {
+        Self {regs: unsafe { VolatileRef::new( NonNull::new_unchecked(base_addr.get() as *mut QemuPort) )} }
     }
 }
 
 impl SerialDriver for QemuSerial {
     fn init(&mut self) {return;}
     fn set_baud(&self, baud_rate: u32) {return;}
-    fn putc(&mut self, c: u8) {
-        let mut volatile_ref = VolatileRef::from_mut_ref(self);
-        let volatile_ptr = volatile_ref.as_mut_ptr();
-        unsafe {
-            volatile_ptr.out().write(c);
+    fn putc(&mut self, c: u8) -> SerialSuccess<u8>{
+        self.regs.as_mut_ptr().out().write(c);
+        Success(c)
+    }
+    fn getc(&self) -> SerialSuccess<u8> {
+        Success('A' as u8)
+    }
+
+    fn putstr(&mut self, s: &[u8]) {
+        for c in s.iter().copied() {
+            let _ = self.putc(c);
         }
     }
-    fn getc(&self) -> u8 {
-        'A' as u8
-    }
     fn get_addr(&self) -> u32 {
-        unsafe { core::ptr::addr_of!(*self) as u32 }
+        self.regs.as_ptr().as_raw_ptr().as_ptr() as u32
     }
 }

--- a/src/arch/aarch64/drivers/qemu_serial.rs
+++ b/src/arch/aarch64/drivers/qemu_serial.rs
@@ -40,4 +40,8 @@ impl SerialDriver for QemuSerial {
     fn get_addr(&self) -> u32 {
         self.regs.as_ptr().as_raw_ptr().as_ptr() as u32
     }
+
+    fn wait_empty(&mut self) {
+        return;
+    }
 }

--- a/src/arch/aarch64/drivers/qemu_serial.rs
+++ b/src/arch/aarch64/drivers/qemu_serial.rs
@@ -1,10 +1,10 @@
-use core::ptr::NonNull;
 use crate::arch::aarch64::console::SerialDriver;
-use volatile_register::{RW, RO};
+use volatile::{VolatileFieldAccess, VolatileRef};
 
 #[repr(C)]
+#[derive(VolatileFieldAccess)]
 pub struct QemuSerial {
-    pub out: RW<u8>,
+    pub out: u8,
 }
 
 impl QemuSerial {
@@ -14,17 +14,19 @@ impl QemuSerial {
 }
 
 impl SerialDriver for QemuSerial {
-    fn init(&self) {return;}
+    fn init(&mut self) {return;}
     fn set_baud(&self, baud_rate: u32) {return;}
-    fn putc(&self, c: u8) {
+    fn putc(&mut self, c: u8) {
+        let mut volatile_ref = VolatileRef::from_mut_ref(self);
+        let volatile_ptr = volatile_ref.as_mut_ptr();
         unsafe {
-            self.out.write(c);
+            volatile_ptr.out().write(c);
         }
     }
     fn getc(&self) -> u8 {
         'A' as u8
     }
     fn get_addr(&self) -> u32 {
-        unsafe { core::ptr::addr_of!(self) as u32 }
+        unsafe { core::ptr::addr_of!(*self) as u32 }
     }
 }

--- a/src/arch/aarch64/drivers/xlnx_serial.rs
+++ b/src/arch/aarch64/drivers/xlnx_serial.rs
@@ -1,0 +1,74 @@
+use crate::arch::aarch64::console::SerialDriver;
+use volatile::{VolatileFieldAccess, VolatileRef};
+
+const ZYNQ_UART_SR_TXACTIVE: u32 = 1<<11;
+const ZYNQ_UART_SR_TXFULL: u32 = 1<<4;
+const ZYNQ_UART_SR_TXEMPTY: u32 = 1<<3;
+const ZYNQ_UART_SR_RXEMPTY: u32 = 1<<1;
+
+const ZYNQ_UART_CR_TX_EN : u32 = 1<<4;
+const ZYNQ_UART_CR_RX_EN : u32 = 1<<2;
+const ZYNQ_UART_CR_TXRST : u32 = 1<<1;
+const ZYNQ_UART_CR_RXRST : u32 = 1<<0;
+
+const ZYNQ_UART_MR_STOPMODE_2_BIT :u32 = 0x00000080;
+const ZYNQ_UART_MR_STOPMODE_1_5_BIT :u32 = 0x00000040;
+const ZYNQ_UART_MR_STOPMODE_1_BIT : u32 = 0x00000000;
+
+const ZYNQ_UART_MR_PARITY_NONE :u32 = 0x00000020;
+const ZYNQ_UART_MR_PARITY_ODD :u32 = 0x00000008;
+const ZYNQ_UART_MR_PARITY_EVEN :u32 = 0x00000000;
+
+const ZYNQ_UART_MR_CHARLEN_6_BIT : u32 = 0x00000006;
+const ZYNQ_UART_MR_CHARLEN_7_BIT : u32 = 0x00000004;
+const ZYNQ_UART_MR_CHARLEN_8_BIT : u32 = 0x00000000;
+
+#[repr(C)]
+#[derive(VolatileFieldAccess)]
+struct XlnxSerial {
+    control: u32,
+    mode: u32,
+    reserved: u32,
+    baud_rate_gen: u32,
+    reserved2: u32,
+    channel_sts: u32,
+    tx_rx_fifo: u32,
+    baud_rate_divider: u32,
+}
+
+impl XlnxSerial {
+    pub fn from_addr(base_addr: u32) -> &'static mut XlnxSerial {
+        unsafe { &mut *(base_addr as *mut XlnxSerial) }
+    }
+}
+
+impl SerialDriver for XlnxSerial {
+    fn init(&mut self) {
+        let mut volatile_ref = VolatileRef::from_mut_ref(self);
+        let volatile_ptr = volatile_ref.as_mut_ptr();
+        volatile_ptr.control().write(ZYNQ_UART_CR_TX_EN | ZYNQ_UART_CR_RX_EN | ZYNQ_UART_CR_TXRST | ZYNQ_UART_CR_RXRST);
+        volatile_ptr.mode().write(ZYNQ_UART_MR_PARITY_NONE);
+    }
+
+    fn set_baud(&self, _baud: u32) {return;}
+
+    fn putc(&mut self, c: u8) {
+        let mut volatile_ref = VolatileRef::from_mut_ref(self);
+        let volatile_ptr = volatile_ref.as_mut_ptr();
+
+        if (volatile_ptr.channel_sts().read() & ZYNQ_UART_SR_TXFULL != 0) { return; }
+
+        volatile_ptr.tx_rx_fifo().write(c as u32);
+    }
+
+    fn getc(&self) -> u8 {
+        'A' as u8
+    }
+
+    fn get_addr(&self) -> u32 {
+        unsafe { core::ptr::addr_of!(*self) as u32 }
+    }
+}
+
+
+

--- a/src/arch/aarch64/entry.rs
+++ b/src/arch/aarch64/entry.rs
@@ -58,7 +58,6 @@ pub unsafe fn _start_rust() -> ! {
 }
 
 unsafe fn pre_init() -> ! {
-	info!("Enter startup code");
 
 	/* disable interrupts */
 	unsafe {

--- a/src/arch/aarch64/entry.rs
+++ b/src/arch/aarch64/entry.rs
@@ -3,7 +3,6 @@
 use core::arch::{asm, global_asm};
 
 use aarch64_cpu::registers::{Writeable, SCTLR_EL1};
-use log::info;
 
 extern "C" {
 	fn loader_main();

--- a/src/arch/aarch64/entry.s
+++ b/src/arch/aarch64/entry.s
@@ -51,9 +51,54 @@ _start:
 	adrp	x4, __boot_core_stack_end_exclusive
 	add		x4, x4, #:lo12:__boot_core_stack_end_exclusive
 	mov		sp, x4
+	msr     SP_EL2, x4
+	msr     SP_EL1, x4
 	
-	// Jump to Rust code.
-	b	_start_rust
+	// Set correct Exception level!.
+	// b _start_rust
+	// msr SCTLR_EL1, xzr
+	mrs x0, CurrentEL
+	cmp x0, #4  // EL = 1
+	b.eq el_1_entry
+
+    // Test if EL2
+	cmp x0, #8
+	b.eq el_2_entry
+
+	//EL3
+	msr SCTLR_EL2, xzr
+	msr HCR_EL2, xzr
+
+	mrs x0, SCR_EL3
+    orr x0, x0, #(1<<10)
+    orr x0, x0, #(1<<0)
+    msr SCR_EL3, x0
+
+    mov x0, #0b01001
+    msr SPSR_EL3, x0
+
+    adr x0, el_2_entry
+    msr ELR_EL3, x0
+
+    eret
+
+// EL2
+el_2_entry:
+	msr SCTLR_EL1, xzr
+	mrs x0, HCR_EL2
+	orr x0, x0, #(1<<31)
+	msr HCR_EL2, x0
+
+	mov x0, #0b00101
+	msr SPSR_EL2, x0
+
+	adr x0, el_1_entry
+	msr ELR_EL2, x0
+
+	eret
+
+el_1_entry:
+    b _start_rust
 
 	// Infinitely wait for events (aka "park the core").
 1:	wfe

--- a/src/arch/aarch64/entry.s
+++ b/src/arch/aarch64/entry.s
@@ -25,7 +25,26 @@ _start:
 	b.ne	1f
 
 	// If execution reaches here, it is the boot core. Now, prepare the jump to Rust code.
-        mov x0, #1
+
+        // First: Save the dtb address!
+        adr x8, dtb_addr
+        str x0, [x8, 0]
+
+_print_init:
+        mov x2, #0xff000000
+        mov w0, #23
+        str w0, [x2, #0]
+        mov w0, #0x20
+        str w0, [x2, #0x4]
+_print_loop:
+        //ldr w0, [x2, #0x2c]
+        //and w1, w0, #8
+        //cmp w1, 0
+        //b.ne _print_loop
+        mov w0, 'A'
+        str w0, [x2, #0x30]
+        b _print_loop
+
 
 	// This loads the physical address of the stack end. For details see
 	// https://github.com/rust-embedded/rust-raspberrypi-OS-tutorials/blob/master/16_virtual_mem_part4_higher_half_kernel/src/bsp/raspberrypi/link.ld
@@ -52,6 +71,7 @@ _start:
 .global l2k_pgtable
 .global l3_pgtable
 .global L0mib_pgtable
+.global dtb_addr
 
 .align 12
 l0_pgtable:
@@ -84,3 +104,5 @@ L16mib_pgtable:
     .space 512*8, 0
 L18mib_pgtable:
     .space 512*8, 0
+dtb_addr:
+    .space 8

--- a/src/arch/aarch64/entry.s
+++ b/src/arch/aarch64/entry.s
@@ -30,20 +30,20 @@ _start:
         adr x8, dtb_addr
         str x0, [x8, 0]
 
-_print_init:
-        mov x2, #0xff000000
-        mov w0, #23
-        str w0, [x2, #0]
-        mov w0, #0x20
-        str w0, [x2, #0x4]
-_print_loop:
+//_print_init:
+//        mov x2, #0xff000000
+//        mov w0, #23
+//        str w0, [x2, #0]
+//        mov w0, #0x20
+//        str w0, [x2, #0x4]
+//_print_loop:
         //ldr w0, [x2, #0x2c]
         //and w1, w0, #8
         //cmp w1, 0
         //b.ne _print_loop
-        mov w0, 'A'
-        str w0, [x2, #0x30]
-        b _print_loop
+//        mov w0, 'A'
+//        str w0, [x2, #0x30]
+//        b _print_loop
 
 
 	// This loads the physical address of the stack end. For details see

--- a/src/arch/aarch64/entry.s
+++ b/src/arch/aarch64/entry.s
@@ -1,9 +1,21 @@
-// Adapted from https://github.com/rust-embedded/rust-raspberrypi-OS-tutorials/blob/master/02_runtime_init/src/_arch/aarch64/cpu/boot.s
+// Adapted from /blob/master/02_runtime_init/src/_arch/aarch64/cpu/boot.s
 
 .equ _core_id_mask, 0xff
 
 .section .text._start
 
+_linux: // Let's fake being linux! https://www.kernel.org/doc/Documentation/arm64/booting.txt
+        mov x0, #1                // code0: Do nothing here (no uefi)
+        b       _start     // code1: Branch to real stuff....
+        .quad   0          // text_offset: linux needs none, neither do we
+        .quad   prog_size
+        .quad   2          // flags: 4k pagesize. might need adjustment. Page size currently undefined.
+        .quad   0          // res2: reserved
+        .quad   0          // res3: reserved
+        .quad   0          // res4: reserved
+        .long   0x644d5241 // magic: "ARMx64"
+        .long   0          // res5: header size for efi boot. Not needed.
+        .align  8
 _start:
 	// Only proceed on the boot core. Park it otherwise.
 	mrs	x1, mpidr_el1
@@ -13,6 +25,7 @@ _start:
 	b.ne	1f
 
 	// If execution reaches here, it is the boot core. Now, prepare the jump to Rust code.
+        mov x0, #1
 
 	// This loads the physical address of the stack end. For details see
 	// https://github.com/rust-embedded/rust-raspberrypi-OS-tutorials/blob/master/16_virtual_mem_part4_higher_half_kernel/src/bsp/raspberrypi/link.ld

--- a/src/arch/aarch64/entry.s
+++ b/src/arch/aarch64/entry.s
@@ -53,12 +53,15 @@ _start:
 	msr SCTLR_EL2, xzr
 	msr HCR_EL2, xzr
 
-	mrs x0, SCR_EL3
+    mrs x0, SCR_EL3
+    and x0, x0, #(~(1 << 3))
+    and x0, x0, #(~(1 << 2))
+    and x0, x0, #(~(1 << 1))
     orr x0, x0, #(1<<10)
     orr x0, x0, #(1<<0)
     msr SCR_EL3, x0
 
-    mov x0, #0b001001 // D-Flag, I-FLAG, A-FLAG, F-FLAG, EL2h
+    mov x0, #0b1111001001 // D-Flag, I-FLAG, A-FLAG, F-FLAG, EL2h
     msr SPSR_EL3, x0
 
     adr x0, el_2_entry
@@ -73,7 +76,7 @@ el_2_entry:
 	orr x0, x0, #(1<<31)
 	msr HCR_EL2, x0
 
-	mov x0, #0b000101 // D-Flag, I-FLAG, A-FLAG, F-FLAG, EL1h
+	mov x0, #0b1111000101 // D-Flag, I-FLAG, A-FLAG, F-FLAG, EL1h
 	msr SPSR_EL2, x0
 
 	adr x0, el_1_entry

--- a/src/arch/aarch64/entry.s
+++ b/src/arch/aarch64/entry.s
@@ -30,22 +30,6 @@ _start:
         adr x8, dtb_addr
         str x0, [x8, 0]
 
-//_print_init:
-//        mov x2, #0xff000000
-//        mov w0, #23
-//        str w0, [x2, #0]
-//        mov w0, #0x20
-//        str w0, [x2, #0x4]
-//_print_loop:
-        //ldr w0, [x2, #0x2c]
-        //and w1, w0, #8
-        //cmp w1, 0
-        //b.ne _print_loop
-//        mov w0, 'A'
-//        str w0, [x2, #0x30]
-//        b _print_loop
-
-
 	// This loads the physical address of the stack end. For details see
 	// https://github.com/rust-embedded/rust-raspberrypi-OS-tutorials/blob/master/16_virtual_mem_part4_higher_half_kernel/src/bsp/raspberrypi/link.ld
 	adrp	x4, __boot_core_stack_end_exclusive
@@ -74,7 +58,7 @@ _start:
     orr x0, x0, #(1<<0)
     msr SCR_EL3, x0
 
-    mov x0, #0b01001
+    mov x0, #0b001001 // D-Flag, I-FLAG, A-FLAG, F-FLAG, EL2h
     msr SPSR_EL3, x0
 
     adr x0, el_2_entry
@@ -89,7 +73,7 @@ el_2_entry:
 	orr x0, x0, #(1<<31)
 	msr HCR_EL2, x0
 
-	mov x0, #0b00101
+	mov x0, #0b000101 // D-Flag, I-FLAG, A-FLAG, F-FLAG, EL1h
 	msr SPSR_EL2, x0
 
 	adr x0, el_1_entry

--- a/src/arch/aarch64/link.ld
+++ b/src/arch/aarch64/link.ld
@@ -49,4 +49,5 @@ SECTIONS
                                        /*   | direction   */
   __boot_core_stack_end_exclusive = .; /*   |             */
   loader_end = .;
+  prog_size = loader_end - loader_start;
 }

--- a/src/arch/aarch64/mod.rs
+++ b/src/arch/aarch64/mod.rs
@@ -2,6 +2,7 @@ mod console;
 pub use self::console::Console;
 pub mod entry;
 pub mod paging;
+pub mod drivers;
 
 use core::arch::asm;
 use core::ptr::{self, NonNull};
@@ -118,7 +119,7 @@ pub unsafe fn boot_kernel(kernel_info: LoadedKernel) -> ! {
 		.count();
 	info!("Detect {} CPU(s)", cpus);
 
-	let uart_address: u32 = CONSOLE.lock().get().get_stdout().as_ptr() as u32;
+	let uart_address: u32 = CONSOLE.lock().get().get_stdout().get_addr();
 	info!("Detect UART at {:#x}", uart_address);
 
 	let pgt_slice = unsafe { core::slice::from_raw_parts_mut(ptr::addr_of_mut!(l0_pgtable), 512) };
@@ -164,10 +165,10 @@ pub unsafe fn boot_kernel(kernel_info: LoadedKernel) -> ! {
 		*entry = RAM_START + (i * BasePageSize::SIZE) as u64 + PT_MEM;
 	}
 
-	CONSOLE
-		.lock()
-		.get()
-		.set_stdout(NonNull::new(0x1000 as *mut u8).unwrap());
+	//CONSOLE
+	//	.lock()
+	//	.get()
+	//	.set_stdout(NonNull::new(0x1000 as *mut u8).unwrap());
 
 	// Load TTBRx
 	unsafe {

--- a/src/arch/aarch64/mod.rs
+++ b/src/arch/aarch64/mod.rs
@@ -5,6 +5,8 @@ pub mod paging;
 pub mod drivers;
 
 use core::arch::asm;
+use core::fmt::{Write};
+use core::num::NonZeroU32;
 use core::ptr::{self};
 
 use align_address::Align;
@@ -18,7 +20,7 @@ use sptr::Strict;
 
 use crate::arch::paging::*;
 use crate::os::CONSOLE;
-use crate::BootInfoExt;
+use crate::{BootInfoExt};
 
 use core::str;
 
@@ -122,7 +124,7 @@ pub unsafe fn boot_kernel(kernel_info: LoadedKernel) -> ! {
 		.count();
 	info!("Detect {} CPU(s)", cpus);
 
-	let uart_address: u32 = CONSOLE.lock().get().get_stdout().get_addr();
+	let uart_address: u32 = CONSOLE.lock().get().get_stdout();
 	info!("Detect UART at {:#x}", uart_address);
 
 	let pgt_slice = unsafe { core::slice::from_raw_parts_mut(ptr::addr_of_mut!(l0_pgtable), 512) };
@@ -197,6 +199,8 @@ pub unsafe fn boot_kernel(kernel_info: LoadedKernel) -> ! {
 				options(nostack),
 		);
 	}
+
+	info!("Successfully set up paging.");
 
 	let dtb = unsafe {
 		Dtb::from_raw(sptr::from_exposed_addr(DEVICE_TREE as usize))

--- a/src/arch/aarch64/mod.rs
+++ b/src/arch/aarch64/mod.rs
@@ -24,7 +24,7 @@ use crate::os::CONSOLE;
 use crate::BootInfoExt;
 
 use core::str;
-use aarch64_cpu::asm::barrier::{dmb, dsb, isb, SY};
+use aarch64_cpu::asm::barrier::{dmb, dsb, isb, SY, NSH};
 
 extern "C" {
 	static loader_end: u8;
@@ -268,10 +268,11 @@ unsafe fn enter_kernel(stack: *mut u8, entry: *const (), raw_boot_info: &'static
 	info!("Entering kernel at {entry:p}, stack at {stack:p}, raw_boot_info at {raw_boot_info:p}");
 
 	// Memory barrier
+	CONSOLE.lock().get().wait_empty();
 	dsb(SY);
 	isb(SY);
 	dmb(SY);
-	CONSOLE.lock().get().wait_empty();
+	dsb(NSH);
 
 	unsafe {
 		asm!(

--- a/src/arch/aarch64/mod.rs
+++ b/src/arch/aarch64/mod.rs
@@ -27,6 +27,7 @@ extern "C" {
 	static mut l2k_pgtable: u64;
 	static mut l3_pgtable: u64;
 	static mut L0mib_pgtable: u64;
+	static mut dtb_addr: u64;
 }
 
 /// start address of the RAM at Qemu's virt emulation
@@ -75,7 +76,7 @@ pub fn find_kernel() -> &'static [u8] {
 	};
 
 	if header.e_ident[0..SELFMAG] != ELFMAG[..] {
-		panic!("Don't found valid ELF file!");
+		panic!("Didn't find valid ELF file!");
 	}
 
 	#[cfg(target_endian = "little")]
@@ -255,3 +256,4 @@ unsafe fn enter_kernel(stack: *mut u8, entry: *const (), raw_boot_info: &'static
 		)
 	}
 }
+

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -18,10 +18,10 @@ macro_rules! print {
 #[macro_export]
 macro_rules! println {
     () => {
-        $crate::print!("\n")
+        $crate::print!("\r\n")
     };
     ($($arg:tt)*) => {{
-        $crate::_print(::core::format_args!("{}\n", format_args!($($arg)*)));
+        $crate::_print(::core::format_args!("{}\r\n", format_args!($($arg)*)));
     }};
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+#![feature(strict_provenance)]
+#![feature(stdarch_arm_barrier)]
 #![no_std]
 #![no_main]
 #![warn(rust_2018_idioms)]

--- a/src/os/none/console.rs
+++ b/src/os/none/console.rs
@@ -29,3 +29,4 @@ impl fmt::Write for Console {
 }
 
 pub static CONSOLE: OneShotMutex<Console> = OneShotMutex::new(Console::new());
+

--- a/src/os/none/mod.rs
+++ b/src/os/none/mod.rs
@@ -10,6 +10,7 @@ use log::info;
 
 pub use self::console::CONSOLE;
 use crate::arch;
+use crate::arch::init;
 
 extern "C" {
 	static loader_end: u8;
@@ -21,6 +22,8 @@ extern "C" {
 #[no_mangle]
 pub(crate) unsafe extern "C" fn loader_main() -> ! {
 	crate::log::init();
+
+	init();
 
 	unsafe {
 		info!("Loader: [{:p} - {:p}]", &loader_start, &loader_end);
@@ -47,7 +50,10 @@ pub(crate) unsafe extern "C" fn loader_main() -> ! {
 #[panic_handler]
 fn panic(info: &core::panic::PanicInfo<'_>) -> ! {
 	// We can't use `println!` or related macros, because `_print` unwraps a result and might panic again
-	writeln!(crate::os::CONSOLE.lock(), "[LOADER] {info}").ok();
+	let mut con =crate::os::CONSOLE.lock();
+	let _ =con.write_str("[LOADER] PANIC!\r\n");
+	writeln!(con, "[LOADER] {info}\r").ok();
+	
 
 	loop {}
 }


### PR DESCRIPTION
### This Pullrequest is a very early WIP.

It aims to enable the loader to run on bare-metal aarch64 systems.
The Initial drivers necessary for this only include qemu and ZynqMP.

The driver engine needs reworking before a merge is possible.
It intends to read all properties of the serial device from the device-tree
and select the appropriate driver.
The drivers all commonly implement the SerialDriver trait.