### PR TITLE
fix(firecracker): support running on GitHub-hosted runners

### DIFF
--- a/src/arch/x86_64/entry.s
+++ b/src/arch/x86_64/entry.s
@@ -131,7 +131,6 @@ L1:
 
     # Set CR3
     mov eax, OFFSET boot_pml4
-    # or eax, (1 << 0)        # set present bit
     mov cr3, eax
 
     # we need to enable PAE modus

--- a/src/arch/x86_64/entry_fc.s
+++ b/src/arch/x86_64/entry_fc.s
@@ -46,8 +46,8 @@ _start:
     pop rdi
 
     # Set CR3
-    mov eax, OFFSET boot_pml4
-    ;or eax, (1 << 0)        # set present bit
+    mov rax, OFFSET boot_pml4
+    ;or rax, (1 << 0)        # set present bit
     mov cr3, rax
 
     lgdt [GDT64.Pointer] # Load the 64-bit global descriptor table.

--- a/src/arch/x86_64/entry_fc.s
+++ b/src/arch/x86_64/entry_fc.s
@@ -50,35 +50,6 @@ _start:
     ;or eax, (1 << 0)        # set present bit
     mov cr3, rax
 
-    # we need to enable PAE modus
-    mov rax, cr4
-    or eax, 1 << 5
-    mov cr4, rax
-
-    # switch to the compatibility mode (which is part of long mode)
-    mov ecx, 0xC0000080
-    rdmsr
-    or eax, 1 << 8
-    wrmsr
-
-
-    # Set CR4
-    mov rax, cr4
-    and eax, 0x00000000fffbf9ff     # disable SSE
-    ;or eax, (1 << 7)       # enable PGE
-    mov cr4, rax
-     
-    # Set CR0 (PM-bit is already set)
-    mov rax, cr0
-    and rax, ~(1 << 2)      # disable FPU emulation
-    or eax, (1 << 1)        # enable FPU montitoring
-    and rax, ~(1 << 30)     # enable caching
-    and rax, ~(1 << 29)     # disable write through caching
-    and rax, ~(1 << 16)	    # allow kernel write access to read-only pages
-    or eax, (1 << 31)       # enable paging
-    mov cr0, rax
-
-
     lgdt [GDT64.Pointer] # Load the 64-bit global descriptor table.
     jmp start64 # Set the code segment and enter 64-bit long mode.
 

--- a/src/arch/x86_64/entry_fc.s
+++ b/src/arch/x86_64/entry_fc.s
@@ -47,7 +47,6 @@ _start:
 
     # Set CR3
     mov rax, OFFSET boot_pml4
-    ;or rax, (1 << 0)        # set present bit
     mov cr3, rax
 
     lgdt [GDT64.Pointer] # Load the 64-bit global descriptor table.


### PR DESCRIPTION
GitHub-hosted runners run on Windows with Hyper-V. They don't like invalid bits in CR3 (last commit).