### PR TITLE
secure boot: allow image verification in EFI boot loader

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -416,6 +416,7 @@ dependencies = [
  "take-static",
  "uart_16550",
  "uefi",
+ "uefi-raw 0.11.0",
  "vm-fdt",
  "x86_64",
 ]
@@ -941,7 +942,7 @@ dependencies = [
  "qemu-exit",
  "ucs2",
  "uefi-macros",
- "uefi-raw",
+ "uefi-raw 0.10.0",
  "uguid",
 ]
 
@@ -961,6 +962,16 @@ name = "uefi-raw"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d246ed5d6fd71c0331f0ac774a6aefb6cb9170a46f83148cacc70b09f82c87bb"
+dependencies = [
+ "bitflags 2.8.0",
+ "uguid",
+]
+
+[[package]]
+name = "uefi-raw"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cad96b8baaf1615d3fdd0f03d04a0b487d857c1b51b19dcbfe05e2e3c447b78"
 dependencies = [
  "bitflags 2.8.0",
  "uguid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,11 +16,14 @@ log = "0.4"
 one-shot-mutex = "0.1"
 sptr = "0.3"
 take-static = "0.1"
+uefi-raw = "0.11.0"
 vm-fdt = { version = "0.3", default-features = false, features = ["alloc"] }
 
 [features]
 default = []
 fc = []
+# If enabled, will refuse to boot if not in secure boot mode
+require-secure-boot = []
 
 [target.'cfg(all(target_os = "none", target_arch = "x86_64"))'.dependencies]
 multiboot = "0.8"

--- a/src/os/mod.rs
+++ b/src/os/mod.rs
@@ -1,5 +1,5 @@
 cfg_if::cfg_if! {
-	if #[cfg(target_os = "none")] {
+	if #[cfg(all(target_os = "none", not(feature = "require-secure-boot")))] {
 		mod none;
 		pub use self::none::*;
 	} else if #[cfg(target_os = "uefi")] {

--- a/src/os/uefi/mod.rs
+++ b/src/os/uefi/mod.rs
@@ -1,5 +1,6 @@
 mod allocator;
 mod console;
+mod secure_boot;
 
 use alloc::vec::Vec;
 use core::ffi::c_void;
@@ -65,6 +66,9 @@ fn read_app() -> Vec<u8> {
 
 	let len = data.len();
 	info!("Read Hermit application from \"{path}\" (size = {len} B)");
+
+	// Verify the image is correct before continuing
+	secure_boot::verify_image_or_panic(&data);
 
 	data
 }

--- a/src/os/uefi/secure_boot.rs
+++ b/src/os/uefi/secure_boot.rs
@@ -1,0 +1,119 @@
+use log::{error, info};
+use uefi::boot::{SearchType, open_protocol_exclusive};
+use uefi::runtime::VariableVendor;
+use uefi::{CStr16, Identify, Status, boot};
+
+use crate::os::uefi::secure_boot::security_lib::Security2ArchProtocol;
+
+pub fn is_secure_boot_enabled() -> bool {
+	let mut string_backing = [0u16; 22];
+	let mut output_buffer = [0u8; 1];
+
+	let result = uefi::runtime::get_variable(
+		CStr16::from_str_with_buf("SecureBoot", &mut string_backing)
+			.expect("failed to convert string"),
+		&VariableVendor::GLOBAL_VARIABLE,
+		&mut output_buffer,
+	);
+
+	match result {
+		Ok(_) => output_buffer[0] == 1,
+		Err(err) => {
+			if err.status() == Status::NOT_FOUND {
+				false
+			} else {
+				panic!("Could not load SecureBoot variable: {:?}", err.status())
+			}
+		}
+	}
+}
+
+pub fn verify_image(image_contents: &[u8]) -> uefi::Result<Status> {
+	let protocol_handle =
+		boot::locate_handle_buffer(SearchType::ByProtocol(&Security2ArchProtocol::GUID))?;
+
+	let protocol_handle = protocol_handle
+		.first()
+		.expect("Security2Arch protocol is missing");
+
+	let protocol = open_protocol_exclusive::<Security2ArchProtocol>(*protocol_handle)?;
+
+	Ok(protocol.authenticate_file(image_contents))
+}
+
+pub fn verify_image_or_panic(image_contents: &[u8]) {
+	if !is_secure_boot_enabled() {
+		if cfg!(feature = "require-secure-boot") {
+			error!(
+				"The loader was compiled with the `require-secure-boot` flag and requires secure boot to be enabled."
+			);
+			panic!("This loader requires secure boot to be enabled");
+		} else {
+			info!("Secure boot is not enabled on this machine");
+		}
+		return;
+	}
+
+	let status = verify_image(image_contents).expect("error encountered while verifying image!");
+
+	if status != Status::SUCCESS {
+		error!(
+			"Secure boot image verification failed with status {:?}",
+			status
+		);
+		panic!("Secure boot image verification failed!");
+	} else {
+		info!("Secure boot image verification passed!");
+	}
+}
+
+mod security_lib {
+	use core::ffi::c_void;
+
+	use uefi::Status;
+	use uefi::proto::unsafe_protocol;
+
+	use crate::os::uefi::secure_boot::security_lib_raw;
+
+	#[repr(transparent)]
+	#[derive(Debug)]
+	#[unsafe_protocol(security_lib_raw::Security2ArchProtocolRaw::GUID)]
+	pub struct Security2ArchProtocol(security_lib_raw::Security2ArchProtocolRaw);
+
+	impl Security2ArchProtocol {
+		pub fn authenticate_file(&self, file_buffer: &[u8]) -> Status {
+			unsafe {
+				(self.0.authenticate_file)(
+					&self.0,
+					core::ptr::null(),
+					file_buffer.as_ptr() as *const c_void,
+					file_buffer.len(),
+					false,
+				)
+			}
+		}
+	}
+}
+
+mod security_lib_raw {
+	use core::ffi::c_void;
+
+	use uefi::{Guid, Status, guid};
+	use uefi_raw::protocol::device_path::DevicePathProtocol;
+
+	#[derive(Debug)]
+	#[repr(C)]
+	pub struct Security2ArchProtocolRaw {
+		pub authenticate_file: unsafe extern "efiapi" fn(
+			this: *const Self,
+			device_path: *const DevicePathProtocol,
+			file_buffer: *const c_void,
+			file_size: usize,
+			boot_policy: bool,
+		) -> Status,
+	}
+
+	impl Security2ArchProtocolRaw {
+		pub const GUID: Guid = guid!("94AB2F58-1438-4EF1-9152-18941A3A0E68");
+	}
+}


### PR DESCRIPTION
This PR adds an automatic verification of the booted kernel when secure boot is enabled.

If secure boot is enabled in a VM, the EFI firmware will verify the signature of the boot loader, but not that of the kernel. This is not very useful. To help with that, the loader will verify that the image is signed using the firmware's services. If secure boot is not enabled, nothing should change.

In addition, a new feature is added that will fail to boot if secure boot is not enabled.