### PR TITLE
feat: migrate aarch64 to fdt crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -391,12 +391,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "hermit-dtb"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89e0de208fa9b99664812350b33072d0d9b3a63caaebb03eeb23316eeedfb8d0"
-
-[[package]]
 name = "hermit-entry"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -421,7 +415,6 @@ dependencies = [
  "cfg-if",
  "fdt",
  "goblin 0.10.0",
- "hermit-dtb",
  "hermit-entry",
  "log",
  "multiboot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ x86_64 = { version = "0.15", default-features = false, features = ["instructions
 
 [target.'cfg(target_arch = "aarch64")'.dependencies]
 aarch64-cpu = "10"
-hermit-dtb = { version = "0.1" }
+fdt = { version = "0.1" }
 goblin = { version = "0.10", default-features = false, features = ["elf64"] }
 
 [target.'cfg(target_os = "uefi")'.dependencies]

--- a/src/arch/aarch64/console.rs
+++ b/src/arch/aarch64/console.rs
@@ -1,6 +1,6 @@
 use core::ptr::NonNull;
 
-use hermit_dtb::Dtb;
+use fdt::Fdt;
 
 pub struct Console {
 	stdout: NonNull<u8>,
@@ -11,15 +11,13 @@ fn stdout() -> u32 {
 	const SERIAL_PORT_ADDRESS: u32 = 0x09000000;
 
 	let dtb = unsafe {
-		Dtb::from_raw(sptr::from_exposed_addr(super::DEVICE_TREE as usize))
+		Fdt::from_ptr(sptr::from_exposed_addr(super::DEVICE_TREE as usize))
 			.expect(".dtb file has invalid header")
 	};
 
-	let property = dtb.get_property("/chosen", "stdout-path");
+	let property = dtb.chosen().stdout();
 	if let Some(stdout) = property {
-		let stdout = core::str::from_utf8(stdout)
-			.unwrap()
-			.trim_matches(char::from(0));
+		let stdout = stdout.name.trim_matches(char::from(0));
 		if let Some(pos) = stdout.find('@') {
 			let len = stdout.len();
 			u32::from_str_radix(&stdout[pos + 1..len], 16).unwrap_or(SERIAL_PORT_ADDRESS)


### PR DESCRIPTION
The aarch64 implementation relied on the hermit-dtb crate. Migrate to the more widespread fdt crate.