### PR TITLE
feat: allow for usage of passed dtb addr

### DIFF
--- a/src/arch/aarch64/console.rs
+++ b/src/arch/aarch64/console.rs
@@ -16,7 +16,7 @@ fn stdout() -> SerialPort {
 	const SERIAL_PORT_ADDRESS: u32 = 0x09000000;
 
 	let dtb = unsafe {
-		Fdt::from_ptr(sptr::from_exposed_addr(super::DEVICE_TREE as usize))
+		Fdt::from_ptr(sptr::from_exposed_addr(super::get_dtb_addr() as usize))
 			.expect(".dtb file has invalid header")
 	};
 

--- a/src/arch/aarch64/entry.s
+++ b/src/arch/aarch64/entry.s
@@ -5,17 +5,20 @@
 .section .text
 
 _linux: // Let's fake being linux! https://www.kernel.org/doc/Documentation/arm64/booting.txt
-    mov x0, #1                // code0: Do nothing here (no uefi)
-    b       _start     // code1: Branch to real stuff....
-    .quad   0          // text_offset: linux needs none, neither do we
+    nop                      // code0: Do nothing here (no uefi)
+    b       _linux_start     // code1: Branch to real stuff....
+    .quad   0                // text_offset: linux needs none, neither do we
     .quad   prog_size
-    .quad   2          // flags: 4k pagesize. might need adjustment. Page size currently undefined.
-    .quad   0          // res2: reserved
-    .quad   0          // res3: reserved
-    .quad   0          // res4: reserved
-    .long   0x644d5241 // magic: "ARMx64"
-    .long   0          // res5: header size for efi boot. Not needed.
+    .quad   2                // flags: 4k pagesize. might need adjustment. Page size currently undefined.
+    .quad   0                // res2: reserved
+    .quad   0                // res3: reserved
+    .quad   0                // res4: reserved
+    .long   0x644d5241       // magic: "ARMx64"
+    .long   0                // res5: header size for efi boot. Not needed.
     .align  8
+_linux_start:
+	adr x8, dtb_addr
+	str x0, [x8, 0]
 _start:
 	// Only proceed on the boot core. Park it otherwise.
 	mrs	x1, mpidr_el1
@@ -100,6 +103,7 @@ el_1_entry:
 .global l2k_pgtable
 .global l3_pgtable
 .global L0mib_pgtable
+.global dtb_addr
 
 .align 12
 l0_pgtable:
@@ -132,3 +136,5 @@ L16mib_pgtable:
     .space 512*8, 0
 L18mib_pgtable:
     .space 512*8, 0
+dtb_addr:
+    .space 8, 0


### PR DESCRIPTION
When using different boot protocols, the dtb address can be passed to the loader. Use the passed dtb address instead of qemu default. Use qemu as fallback.