### PR TITLE
feat(uefi): prefer loading kernels from `\EFI\hermit`

### DIFF
--- a/src/os/uefi/mod.rs
+++ b/src/os/uefi/mod.rs
@@ -135,11 +135,14 @@ impl Esp {
 	}
 
 	pub fn read_app(&mut self) -> Vec<u8> {
-		self.read_app_at(cstr16!(r"\EFI\BOOT\hermit-app")).unwrap()
+		self.read_app_at(cstr16!(r"\EFI\hermit\hermit-app"))
+			.or_else(|| self.read_app_at(cstr16!(r"\EFI\BOOT\hermit-app")))
+			.unwrap()
 	}
 
 	pub fn read_bootargs(&mut self) -> Option<String> {
-		self.read_bootargs_at(cstr16!(r"\EFI\BOOT\hermit-bootargs"))
+		self.read_bootargs_at(cstr16!(r"\EFI\hermit\hermit-bootargs"))
+			.or_else(|| self.read_bootargs_at(cstr16!(r"\EFI\BOOT\hermit-bootargs")))
 	}
 
 	fn read_app_at<P: AsRef<Path>>(&mut self, path: P) -> Option<Vec<u8>> {

--- a/xtask/src/ci/qemu.rs
+++ b/xtask/src/ci/qemu.rs
@@ -89,9 +89,11 @@ impl Qemu {
 				// EDK II: https://github.com/tianocore/edk2/blob/edk2-stable202511/MdePkg/Include/Uefi/UefiSpec.h#L2264-L2273
 				sh.create_dir("target/esp/EFI/BOOT")?;
 				sh.copy_file(self.build.dist_object(), "target/esp/EFI/BOOT/BOOTX64.EFI")?;
+
+				sh.create_dir("target/esp/EFI/hermit")?;
 				sh.copy_file(
 					self.build.ci_image(self.image.as_deref().unwrap()),
-					"target/esp/EFI/BOOT/hermit-app",
+					"target/esp/EFI/hermit/hermit-app",
 				)?;
 			}
 			Target::Aarch64Elf | Target::Aarch64BeElf if self.u_boot => {


### PR DESCRIPTION
This moves the hermit app and bootargs config from `\EFI\BOOT` to `\EFI\hermit`. The loader itself will still live at `\EFI\BOOT\BOOTX64.EFI` or wherever it can be booted from.

Prior work:

- Debian: `\EFI\debian`
- Ubuntu: `\EFI\ubuntu`
- Arch Linux: `\EFI\arch`
- Fedora: `\EFI\fedora`
- CentOS: `\EFI\centos`
- Rocky Linux: `\EFI\rocky`
- openSUSE: `\EFI\opensuse`
- Microsoft Windows: `\EFI\Microsoft\Boot` and `\EFI\Microsoft\Recovery`