### PR TITLE
feat(x86_64): remove physical memory workaround

### DIFF
--- a/src/arch/x86_64/platform/linux/mod.rs
+++ b/src/arch/x86_64/platform/linux/mod.rs
@@ -58,8 +58,6 @@ pub fn find_kernel() -> &'static [u8] {
 	let free_addr = ptr::addr_of!(loader_end)
 		.addr()
 		.align_up(Size2MiB::SIZE as usize);
-	// TODO: Workaround for https://github.com/hermitcore/loader/issues/96
-	let free_addr = free_addr.max(0x800000);
 	// Memory after the highest end address is unused and available for the physical memory manager.
 	info!("Intializing PhysAlloc with {free_addr:#x}");
 	PhysAlloc::init(free_addr);

--- a/src/arch/x86_64/platform/multiboot/mod.rs
+++ b/src/arch/x86_64/platform/multiboot/mod.rs
@@ -133,10 +133,8 @@ pub fn find_kernel() -> &'static [u8] {
 	}
 
 	let modules_mapping_end = end_address.align_up(Size2MiB::SIZE) as usize;
-	// TODO: Workaround for https://github.com/hermitcore/loader/issues/96
-	let free_memory_address = cmp::max(modules_mapping_end, 0x800000);
 	// Memory after the highest end address is unused and available for the physical memory manager.
-	PhysAlloc::init(free_memory_address);
+	PhysAlloc::init(modules_mapping_end);
 
 	// Identity-map the ELF header of the first module and until the 2 MiB
 	// mapping starts. We cannot start the 2 MiB mapping right from


### PR DESCRIPTION
Revert "x86_64: Have 0x800000 as minimal physical memory start"

This reverts commit bf56601650a38d883822af86d71a358280745fb5.