### PR TITLE
fix(aarch64): don't use atomics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -520,6 +520,7 @@ dependencies = [
  "goblin",
  "hermit-entry",
  "linux-boot-params",
+ "lock_api",
  "log",
  "multiboot",
  "naked-function",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,8 @@ aarch64-cpu = "11"
 enum_dispatch = "0.3"
 fdt = { version = "0.1" }
 goblin = { version = "0.10", default-features = false, features = ["elf64"] }
+# FIXME: remove this once we have early page tables on ARM.
+lock_api = "0.4"
 tock-registers = "0.10"
 volatile = { version = "0.6", features = ["derive"] }
 

--- a/src/log.rs
+++ b/src/log.rs
@@ -5,7 +5,13 @@ use log::{Level, LevelFilter, Metadata, Record, info};
 
 pub fn init() {
 	static LOGGER: Logger = Logger;
-	log::set_logger(&LOGGER).unwrap();
+	cfg_select! {
+		target_arch = "aarch64" => unsafe {
+			// FIXME: remove this once we have early page tables on ARM.
+			log::set_logger_racy(&LOGGER).unwrap();
+		}
+		_ => log::set_logger(&LOGGER).unwrap(),
+	}
 	let level_filter = option_env!("LOADER_LOG")
 		.map(|var| var.parse().unwrap())
 		.unwrap_or(LevelFilter::Info);

--- a/src/os/none/console.rs
+++ b/src/os/none/console.rs
@@ -1,7 +1,5 @@
 use core::fmt;
 
-use one_shot_mutex::sync::OneShotMutex;
-
 use crate::arch;
 
 pub struct Console {
@@ -28,4 +26,16 @@ impl fmt::Write for Console {
 	}
 }
 
-pub static CONSOLE: OneShotMutex<Console> = OneShotMutex::new(Console::new());
+cfg_select! {
+	target_arch = "aarch64" => {
+		use super::unsound_mutex::UnsoundMutex;
+
+		// FIXME: remove this once we have early page tables on ARM.
+		pub static CONSOLE: UnsoundMutex<Console> = UnsoundMutex::new(Console::new());
+	}
+	_ => {
+		use one_shot_mutex::sync::OneShotMutex;
+
+		pub static CONSOLE: OneShotMutex<Console> = OneShotMutex::new(Console::new());
+	}
+}

--- a/src/os/none/mod.rs
+++ b/src/os/none/mod.rs
@@ -1,5 +1,7 @@
 mod allocator;
 mod console;
+#[cfg(target_arch = "aarch64")]
+mod unsound_mutex;
 
 use core::fmt::Write;
 use core::mem::MaybeUninit;

--- a/src/os/none/unsound_mutex.rs
+++ b/src/os/none/unsound_mutex.rs
@@ -1,0 +1,19 @@
+use lock_api::{GuardSend, RawMutex};
+
+pub struct RawUnsoundMutex;
+
+unsafe impl RawMutex for RawUnsoundMutex {
+	const INIT: RawUnsoundMutex = RawUnsoundMutex;
+
+	type GuardMarker = GuardSend;
+
+	fn lock(&self) {}
+
+	fn try_lock(&self) -> bool {
+		true
+	}
+
+	unsafe fn unlock(&self) {}
+}
+
+pub type UnsoundMutex<T> = lock_api::Mutex<RawUnsoundMutex, T>;


### PR DESCRIPTION
On many aarch64 systems, atomic operations can only be used if paging (and caching) is enabled. Apple processors are an example of behavior.

To accelerate QEMU using Apple's Hypervisor Framework, the usage of atomic instructions had to be avoided. Therefore, a null-mutex was introduced for this architecture, which always allows access.

With these changes, it is possible to accelerate Qemu as follows:

```
qemu-system-aarch64 \
    -display none -serial stdio \
    -kernel hermit-loader-aarch64 \
    -machine virt,gic-version=3,accel=hvf \
    -cpu host \
    -semihosting \
    -smp 1 -m 2G \
    -global virtio-mmio.force-legacy=off \
    -netdev user,id=net0,hostfwd=tcp::9975-:9975,hostfwd=udp::9975-:9975,net=192.168.76.0/24,dhcpstart=192.168.76.9 \
    -device virtio-net-pci,netdev=net0,disable-legacy=on,packed=on,mq=on \
    -device guest-loader,addr=0x48000000,initrd=PATH_TO_THE_IMAGE
```