### PR TITLE
fix(aarch64): Move image back a little

### DIFF
--- a/src/arch/aarch64/link.ld
+++ b/src/arch/aarch64/link.ld
@@ -3,7 +3,7 @@
 */
 
 ENTRY(_start)
-phys = 0x40200000;
+phys = 0x40400000;
 
 PHDRS
 {


### PR DESCRIPTION
This is for compatibility with cloud-hypervisor, which puts its ACPI tables at 0x40200000.