### PR TITLE
refactor: migrate to elf-symbols crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -365,6 +365,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "elf-symbols"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1c04d6bdc16d03d4e204d6cd018db65f0947013bb4129d1f9a935ff9562af9e"
+
+[[package]]
 name = "enum_dispatch"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -506,6 +512,7 @@ dependencies = [
  "anyhow",
  "built",
  "cfg-if",
+ "elf-symbols",
  "enum_dispatch",
  "fdt",
  "goblin",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ align-address = "0.4"
 allocator-api2 = { version = "0.4", default-features = false }
 anstyle = { version = "1", default-features = false }
 cfg-if = "1"
+elf-symbols = "0.1"
 hermit-entry = { version = "0.10", features = ["loader"] }
 log = "0.4"
 one-shot-mutex = "0.2"

--- a/src/arch/aarch64/mod.rs
+++ b/src/arch/aarch64/mod.rs
@@ -32,7 +32,7 @@ const KERNEL_STACK_SIZE: usize = 32_768;
 const DEVICE_TREE: u64 = RAM_START;
 
 pub unsafe fn get_memory(_memory_size: u64) -> u64 {
-	let loader_end = crate::os::executable_end().as_ptr();
+	let loader_end = elf_symbols::executable_end();
 	(loader_end.expose_provenance() as u64).align_up(LargePageSize::SIZE as u64)
 }
 

--- a/src/arch/x86_64/platform/linux/mod.rs
+++ b/src/arch/x86_64/platform/linux/mod.rs
@@ -37,7 +37,7 @@ unsafe extern "C" fn rust_start(boot_params: *mut BootParams) -> ! {
 	crate::log::init();
 	BOOT_PARAMS.store(boot_params, Ordering::Relaxed);
 
-	let loader_end = crate::os::executable_end().as_ptr();
+	let loader_end = elf_symbols::executable_end();
 	let free_addr = loader_end.addr().align_up(Size2MiB::SIZE as usize);
 	// Memory after the highest end address is unused and available for the physical memory manager.
 	info!("Intializing PhysAlloc with {free_addr:#x}");
@@ -80,7 +80,7 @@ pub unsafe fn boot_kernel(kernel_info: LoadedKernel) -> ! {
 	let boot_params_ref = unsafe { BootParams::get() };
 
 	// determine boot stack address
-	let loader_end = crate::os::executable_end().as_ptr();
+	let loader_end = elf_symbols::executable_end();
 	let stack = (loader_end.addr() + Size4KiB::SIZE as usize).align_up(Size4KiB::SIZE as usize);
 	let stack = loader_end.with_addr(stack).cast::<u8>();
 	// clear stack

--- a/src/arch/x86_64/platform/multiboot/mod.rs
+++ b/src/arch/x86_64/platform/multiboot/mod.rs
@@ -17,7 +17,6 @@ use crate::BootInfoExt;
 use crate::arch::x86_64::physicalmem::PhysAlloc;
 use crate::arch::x86_64::{KERNEL_STACK_SIZE, SERIAL_IO_PORT, page_tables};
 use crate::fdt::Fdt;
-use crate::os::executable_end;
 
 #[allow(bad_asm_style)]
 mod entry {
@@ -145,7 +144,7 @@ pub unsafe fn boot_kernel(kernel_info: LoadedKernel) -> ! {
 	let multiboot = unsafe { Multiboot::from_ptr(mb_info as u64, &mut mem).unwrap() };
 
 	// determine boot stack address
-	let loader_end = executable_end().as_ptr();
+	let loader_end = elf_symbols::executable_end();
 	let mut new_stack = loader_end.addr().align_up(Size4KiB::SIZE as usize);
 
 	if new_stack + KERNEL_STACK_SIZE as usize > mb_info.addr() {

--- a/src/os/none/mod.rs
+++ b/src/os/none/mod.rs
@@ -5,7 +5,6 @@ mod unsound_mutex;
 
 use core::fmt::Write;
 use core::mem::MaybeUninit;
-use core::ptr::NonNull;
 use core::{ptr, slice};
 
 use hermit_entry::elf::KernelObject;
@@ -14,31 +13,11 @@ use log::info;
 pub use self::console::CONSOLE;
 use crate::arch;
 
-pub fn executable_start() -> NonNull<()> {
-	unsafe extern "C" {
-		static mut __executable_start: u8;
-	}
-
-	let ptr = &raw mut __executable_start;
-	let ptr = ptr.cast::<()>();
-	NonNull::new(ptr).unwrap()
-}
-
-pub fn executable_end() -> NonNull<()> {
-	unsafe extern "C" {
-		static mut _end: u8;
-	}
-
-	let ptr = &raw mut _end;
-	let ptr = ptr.cast::<()>();
-	NonNull::new(ptr).unwrap()
-}
-
 /// Entry Point of the BIOS Loader
 /// (called from entry.asm or entry.rs)
 pub(crate) unsafe extern "C" fn loader_main() -> ! {
-	let loader_start = executable_start();
-	let loader_end = executable_end();
+	let loader_start = elf_symbols::executable_start();
+	let loader_end = elf_symbols::executable_end();
 	info!("Loader: [{loader_start:p} - {loader_end:p}]");
 
 	let kernel = arch::find_kernel();


### PR DESCRIPTION
I have extracted these linker-defined ELF symbols into an [elf-symbols](https://docs.rs/elf-symbols/0.1.0/elf_symbols/) crate.